### PR TITLE
refactor: remove unused components and sparkle animation

### DIFF
--- a/app/[lang]/(home)/_components.tsx
+++ b/app/[lang]/(home)/_components.tsx
@@ -68,7 +68,6 @@ const createConfetti = (e: React.MouseEvent) => {
 
 export function ProjectsShowcase(props: { className?: string }) {
   const { className } = props
-  const t = useTranslations('homePage')
 
   return (
     <div className={cn('w-full py-20 bg-gray-50/50 dark:bg-gray-900/50', className)}>

--- a/app/[lang]/(home)/page.tsx
+++ b/app/[lang]/(home)/page.tsx
@@ -2,7 +2,7 @@
 
 import { useTheme } from 'next-themes'
 import { useEffect, useState, useRef } from 'react'
-import { Hero, ProjectsShowcase } from '@/app/[lang]/(home)/_components'
+import { Hero } from '@/app/[lang]/(home)/_components'
 
 const BackgroundVideo = () => {
   const { resolvedTheme } = useTheme()

--- a/components/ui/github-star-button.tsx
+++ b/components/ui/github-star-button.tsx
@@ -49,7 +49,6 @@ function useCountAnimation(endValue: number | null, duration: number = 8000) {
 export function GitHubStarButton({ repo, className = '' }: GitHubStarButtonProps) {
   const [starCount, setStarCount] = useState<number | null>(null)
   const [isHovered, setIsHovered] = useState(false)
-  const [showSparkles, setShowSparkles] = useState(false)
   const animatedCount = useCountAnimation(starCount)
 
   useEffect(() => {
@@ -63,10 +62,7 @@ export function GitHubStarButton({ repo, className = '' }: GitHubStarButtonProps
           setStarCount(data.stargazers_count)
           
           // Only show sparkles for fresh data, not cached
-          if (!data.from_cache) {
-            setTimeout(() => setShowSparkles(true), 1000)
-            setTimeout(() => setShowSparkles(false), 3000)
-          }
+          // Note: Sparkle animation removed
         } else {
           // Handle API errors (including rate limits)
           const errorData = await response.json().catch(() => ({}))
@@ -93,8 +89,6 @@ export function GitHubStarButton({ repo, className = '' }: GitHubStarButtonProps
   const formatStarCount = (count: number) => count.toLocaleString()
 
   const handleClick = () => {
-    setShowSparkles(true)
-    setTimeout(() => setShowSparkles(false), 2000)
     window.open(`https://github.com/${repo}`, '_blank', 'noopener,noreferrer')
   }
 


### PR DESCRIPTION
- Remove ProjectsShowcase component import and usage
- Remove unused translation hook in ProjectsShowcase
- Remove sparkle animation logic from GitHubStarButton