### PR TITLE
fix: update page name in meta.json for consistency

### DIFF
--- a/content/docs/ten_framework/(latest)/meta.json
+++ b/content/docs/ten_framework/(latest)/meta.json
@@ -3,7 +3,7 @@
   "description": "latest",
   "root": true,
   "pages": [
-    "getting_started",
+    "getting-started",
     "concept_overview",
     "preparation",
     "version_system",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rename `pages` entry from `getting_started` to `getting-started` in `content/docs/ten_framework/(latest)/meta.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c16c2ead02928a1bfa39f569fd247c5f66f0585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->