### PR TITLE
Move Portal Build/Deploy to GitHub Actions to Fix Netlify Build Hang

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -1,0 +1,76 @@
+name: Netlify Deploy
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        # ✅ Only run for PRs targeting main
+        branches:
+            - main
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+
+        env:
+            NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+            NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Build (Next / Fumadocs)
+              run: bun run build
+
+            - name: Install Netlify CLI
+              run: bun add -g netlify-cli
+
+            # ========= PR: deploy preview =========
+            - name: Deploy Preview to Netlify
+              # ✅ Only for PRs whose base is main (double guard)
+              if: github.event_name == 'pull_request' && github.base_ref == 'main'
+              id: netlify_preview
+              run: |
+                  OUTPUT=$(netlify deploy \
+                    --auth "$NETLIFY_AUTH_TOKEN" \
+                    --site "$NETLIFY_SITE_ID" \
+                    --dir ".next" \
+                    --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}" \
+                    --draft \
+                    --json)
+
+                  echo "$OUTPUT"
+                  echo "NETLIFY_OUTPUT<<EOF" >> $GITHUB_OUTPUT
+                  echo "$OUTPUT" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
+            - name: Comment Preview URL on PR
+              if: github.event_name == 'pull_request' && github.base_ref == 'main'
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: netlify-preview
+                  message: |
+                      ✅ Netlify Preview deployed successfully.
+
+                      Preview URL: ${{ fromJson(steps.netlify_preview.outputs.NETLIFY_OUTPUT).deploy_url }}
+
+            # ========= main: deploy production =========
+            - name: Deploy Production to Netlify
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              run: |
+                  netlify deploy \
+                    --auth "$NETLIFY_AUTH_TOKEN" \
+                    --site "$NETLIFY_SITE_ID" \
+                    --dir ".next" \
+                    --message "Production deploy - ${{ github.sha }}" \
+                    --prod


### PR DESCRIPTION
## Summary

Netlify builds for the Portal project were consistently hanging while generating
300+(or more) static pages. This PR moves all builds to GitHub Actions, using Netlify
only for hosting.

## Changes

- Added GitHub Actions workflow for PR Preview + Production deploys.
- Added sticky PR comments with Preview URLs.
- Disabled Netlify native builds to avoid timeouts.

## Reason

Netlify CI cannot reliably complete large Fumadocs/Next.js builds. GitHub
Actions provides more stable build capacity.